### PR TITLE
Lock parent docker image to 2.3 Ruby

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:alpine
+FROM ruby:2.3-alpine
 
 ARG BUNDLE_WITHOUT=test:development
 ENV BUNDLE_WITHOUT ${BUNDLE_WITHOUT}


### PR DESCRIPTION
`ruby:alpine` was updated to point to Ruby 2.4.  With the changes surrounding `Fixnum` in 2.4, updating requires some manual work.  The resolution?  Don't upgrade to 2.4 right now!!