### PR TITLE
Switch to public docker hub repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,11 +38,10 @@ jobs:
       - checkout
       - run:
           command: |
-            pip install --upgrade awscli
-            $(aws ecr get-login --region us-east-1 --no-include-email)
             docker build -t lcapi .
-            docker tag lcapi:latest $DOCKER_REPOSITORY:latest
-            docker push $DOCKER_REPOSITORY:latest
+            docker login -u $DOCKER_USER -p $DOCKER_PASS
+            docker tag lcapi:latest lansingcodes/lcapi:latest
+            docker push lansingcodes/lcapi:latest
             ssh lcapi@aws-docker-1.atomaka.com "bash /home/lcapi/deploy.sh"
 workflows:
   version: 2

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -2,7 +2,9 @@
 
 cd $HOME
 
-sudo $(aws ecr get-login --region us-east-1)
+source ./dockerrc
+
+echo $DOCKER_PASS | sudo docker login --username $DOCKER_USER --password-stdin
 sudo docker-compose pull lcapi
 sudo docker-compose stop lcapi
 sudo docker-compose rm -f lcapi

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   lcapi:
-    image: 904999972394.dkr.ecr.us-east-1.amazonaws.com/lcapi
+    image: lansingcodes/lcapi
     env_file: lcapirc
     restart: always
     networks:

--- a/deploy/dockerrc.sample
+++ b/deploy/dockerrc.sample
@@ -1,0 +1,3 @@
+# docker settings
+DOCKER_USER=
+DOCKER_PASS=


### PR DESCRIPTION
Currently, docker images are stored on my private AWS account. Since no images require privacy, we can deploy these using the docker hub.