### PR TITLE
Switch to Hippocratic license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,42 @@
-The MIT License (MIT)
+The Hippocratic License (MIT - Hippocratic)
 
-Copyright (c) 2015-present, Humanity Codes LLC
+Copyright 2015-present Humanity Codes LLC
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+* The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+* No Harm: The software may not be used by anyone for systems or activities that
+actively and knowingly endanger, harm, or otherwise threaten the physical,
+mental, economic, or general well-being of other individuals or groups in
+violation of the United Nations Universal Declaration of Human Rights
+(https://www.un.org/en/universal-declaration-human-rights/).
+
+* Services: If the Software is used to provide a service to others, the licensee
+shall, as a condition of use, require those others not to use the service in any
+way that violates the No Harm clause above.
+
+* Enforceability. If any portion or provision of this License shall to any
+extent be declared illegal or unenforceable by a court of competent
+jurisdiction, then the remainder of this License, or the application of such
+portion or provision in circumstances other than those as to which it is so
+declared illegal or unenforceable, shall not be affected thereby, and each
+portion and provision of this Agreement shall be valid and enforceable to the
+fullest extent permitted by law.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+This Hippocratic License is an Ethical Source license
+(https://ethicalsource.dev) derived from the MIT License, amended to limit the
+impact of the unethical use of open source software.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,6 @@ Before you get ahead of yourself, though, please read our
 
 ## License
 
-[MIT](http://opensource.org/licenses/MIT)
+[MIT - Hippocratic](https://firstdonoharm.dev)
 
 Copyright (c) 2015-present, Humanity Codes LLC

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "Erik Gillespie <erik.gillespie@gmail.com>",
     "Meg Blaha"
   ],
-  "license": "MIT",
+  "license": "MIT - Hippocratic",
   "private": true,
   "scripts": {
     "precommit": "run-s lint test",


### PR DESCRIPTION
@KatieMFritz We'll chat about this tomorrow, but I wanted to drop in some highlights.

This change uses a more specific version of the MIT licenses called the Hippocratic license. The gist of this new license is that it discourages anyone who violates human rights (according to the UN definition) from using the software. It's undergone legal review and I've annotated the changes according to the documentation at [firstdonoharm.dev](https://firstdonoharm.dev).