### PR TITLE
Delete events before loading new ones (fixes #44, #40)

### DIFF
--- a/src/firebase/constants/max-events.js
+++ b/src/firebase/constants/max-events.js
@@ -1,0 +1,2 @@
+// The maximum number of conceivable events scheduled at a given time
+module.exports = parseInt(process.env.MAX_EVENTS) || 9999

--- a/src/firebase/event-paths-get-all.js
+++ b/src/firebase/event-paths-get-all.js
@@ -1,0 +1,14 @@
+const initializeHttpClient = require('./http/initialize-http-client')
+const documentPath = require('./builders/document-path')
+const maxEvents = require('./constants/max-events')
+
+const eventsPath = documentPath({ collection: 'events' })
+const eventKeysUrl = `${eventsPath}?pageSize=${maxEvents}&mask.fieldPaths=key`
+
+module.exports = () =>
+  initializeHttpClient().then(firebaseHttpClient =>
+    firebaseHttpClient.get(eventKeysUrl).then(response => {
+      if (!response.data || !response.data.documents) return []
+      return response.data.documents.map(document => document.name)
+    })
+  )

--- a/src/firebase/events-delete.js
+++ b/src/firebase/events-delete.js
@@ -1,0 +1,6 @@
+const initializeHttpClient = require('./http/initialize-http-client')
+
+module.exports = eventPaths =>
+  initializeHttpClient().then(firebaseHttpClient =>
+    eventPaths.map(eventPath => firebaseHttpClient.delete(eventPath))
+  )

--- a/src/load-events.js
+++ b/src/load-events.js
@@ -1,7 +1,15 @@
+const getAllEventPaths = require('./firebase/event-paths-get-all')
+const deleteEvents = require('./firebase/events-delete')
 const setFutureEvents = require('./firebase/events-set-future')
 
+// Get and delete all events first to:
+//  1. Remove past events
+//  2. Remove canceled events
+//  3. Remove events with new keys (happens in Meetup after certain edits)
 export function handler(event, context, callback) {
-  setFutureEvents()
+  getAllEventPaths()
+    .then(eventPaths => deleteEvents(eventPaths))
+    .then(() => setFutureEvents())
     .then(() => {
       callback(null, {
         statusCode: 200,


### PR DESCRIPTION
Deletes all events before loading new ones to prevent duplication of events and reduce the overall datastore size.

Resolves #44.
Resolves #40.